### PR TITLE
feat: improve 15 skill definitions via tessl skill review

### DIFF
--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -185,6 +185,14 @@ agent-browser dialog dismiss        # Dismiss dialog
 agent-browser eval "document.title"   # Run JavaScript
 ```
 
+## Error handling
+
+- **Element not found / stale ref**: Re-snapshot with `agent-browser snapshot -i` to get fresh refs, then retry.
+- **Timeout waiting for element**: Use `agent-browser wait 2000` to pause, then re-snapshot. Check `agent-browser errors` for page errors.
+- **Command fails after navigation**: DOM may have changed — always re-snapshot after page transitions or significant DOM updates.
+- **Unexpected dialog blocking interaction**: Use `agent-browser dialog accept` or `agent-browser dialog dismiss` to clear it, then continue.
+- **Element not interactable**: Try `agent-browser scrollintoview @e1` first, then retry the interaction.
+
 ## Example: Form submission
 
 ```bash
@@ -197,6 +205,10 @@ agent-browser fill @e2 "password123"
 agent-browser click @e3
 agent-browser wait --load networkidle
 agent-browser snapshot -i  # Check result
+
+# Verify success: check for a success message or URL change
+agent-browser get url      # Confirm redirect, e.g. to /confirmation
+agent-browser wait --text "Thank you"  # Or wait for a known success string
 ```
 
 ## Example: Authentication with saved state
@@ -235,11 +247,6 @@ agent-browser get text @e1 --json
 ## Debugging
 
 ```bash
-agent-browser open example.com --headed              # Show browser window
-agent-browser console                                # View console messages
-agent-browser errors                                 # View page errors
-agent-browser record start ./debug.webm   # Record from current page
-agent-browser record stop                            # Save recording
 agent-browser open example.com --headed  # Show browser window
 agent-browser --cdp 9222 snapshot        # Connect via CDP
 agent-browser console                    # View console messages
@@ -247,6 +254,8 @@ agent-browser console --clear            # Clear console
 agent-browser errors                     # View page errors
 agent-browser errors --clear             # Clear errors
 agent-browser highlight @e1              # Highlight element
+agent-browser record start ./debug.webm  # Record from current page
+agent-browser record stop                # Save recording
 agent-browser trace start                # Start recording trace
 agent-browser trace stop trace.zip       # Stop and save trace
 ```

--- a/skills/bun/SKILL.md
+++ b/skills/bun/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun
-description: Use Bun instead of Node.js, npm, pnpm, or vite. Provides command mappings, Bun-specific APIs, and development patterns.
+description: Use when the user wants to use Bun, migrate from Node.js/npm/pnpm/Vite, or asks about Bun-specific features. Runs scripts with `bun run`, installs packages with `bun install`, bundles code with `bun build`, and replaces Node.js/npm/pnpm/Vite with Bun-native APIs and tooling.
 ---
 
 # Bun Runtime

--- a/skills/chrome-webstore-release-blueprint/SKILL.md
+++ b/skills/chrome-webstore-release-blueprint/SKILL.md
@@ -5,22 +5,7 @@ description: Guide a user end-to-end through setting up Chrome Web Store API rel
 
 # Chrome Web Store Release Blueprint
 
-Use this skill as a hands-on setup guide. The agent should lead the user step-by-step, ask for confirmations, and only automate the parts that can be done locally/in CI.
-
-## What This Skill Is For
-
-- Helping a user set up Chrome Web Store release automation from scratch.
-- Giving clear manual instructions for Google/CWS dashboard steps.
-- Implementing repo-side scripts/workflows after the user provides credentials.
-- Verifying submission state (`PUBLISHED`, `PENDING_REVIEW`, etc.).
-
-## Agent Behavior Rules
-
-- Treat dashboard/OAuth tasks as user-driven; do not imply you performed them.
-- Give one clear step at a time and wait for confirmation before moving on.
-- Ask for exact values only when needed, and tell user where each value comes from.
-- Mask secrets in logs and never commit secret values to git.
-- If `gh` is available, offer secret upload automation; if not, provide manual fallback.
+Use this skill as a hands-on setup guide. Lead the user step-by-step, treating all Google/OAuth dashboard tasks as user-driven, giving one clear step at a time and waiting for confirmation before moving on. Ask for exact values only when needed and tell the user where each value comes from. Mask secrets in logs, never commit secret values to git, and prefer repeatable helper scripts over ad-hoc commands. If `gh` is available, offer secret upload automation; if not, provide a manual fallback.
 
 ## Step 1: Project Discovery (Before Any Credential Work)
 
@@ -41,81 +26,50 @@ Ask explicitly:
 
 ### 2.1 Enable API in Google Cloud
 
-Tell user to open:
-- `https://console.cloud.google.com/apis/library/chromewebstore.googleapis.com`
+Open: `https://console.cloud.google.com/apis/library/chromewebstore.googleapis.com`
 
-User actions:
-1. Select the intended Google Cloud project.
-2. Click `Enable` for Chrome Web Store API.
-
-Agent prompt example:
-- "When Chrome Web Store API shows as Enabled, tell me and I will move to OAuth setup."
+- [ ] Select the intended Google Cloud project
+- [ ] Click `Enable` for Chrome Web Store API
+- [ ] Confirm "Enabled" status before continuing
 
 ### 2.2 Configure OAuth Consent Screen
 
-Tell user to open one of:
-- `https://console.cloud.google.com/apis/credentials/consent`
-- If UI redirects, continue in Google Auth Platform consent screen pages.
+Open: `https://console.cloud.google.com/apis/credentials/consent`
+(If UI redirects, continue in Google Auth Platform consent screen pages.)
 
-User actions:
-1. Choose `External` user type (for non-Workspace internal apps).
-2. Fill app name, support email, developer contact email.
-3. Save and continue through scopes unless custom scopes are required.
-4. Add your own Google account as a test user if app is in Testing mode.
-5. Save.
+- [ ] Choose `External` user type
+- [ ] Fill app name, support email, developer contact email; save and continue through scopes
+- [ ] Add your own Google account as a test user if app is in Testing mode
 
-Agent guidance:
-- If user wants stable long-lived refresh token behavior, recommend moving consent screen to Production when ready.
+> For stable long-lived refresh token behavior, recommend moving consent screen to Production when ready.
 
 ### 2.3 Create OAuth Client
 
-Tell user to open:
-- `https://console.cloud.google.com/apis/credentials`
+Open: `https://console.cloud.google.com/apis/credentials`
 
-User actions:
-1. Click `Create Credentials` -> `OAuth client ID`.
-2. Choose application type `Web application`.
-3. Add authorized redirect URI exactly:
-- `https://developers.google.com/oauthplayground`
-4. Create client.
+- [ ] Click `Create Credentials` → `OAuth client ID` → application type `Web application`
+- [ ] Add authorized redirect URI exactly: `https://developers.google.com/oauthplayground`
+- [ ] Save both values as `CWS_CLIENT_ID` and `CWS_CLIENT_SECRET`
 
-Capture values:
-- `CWS_CLIENT_ID`
-- `CWS_CLIENT_SECRET`
-
-Agent prompt example:
-- "Paste `CWS_CLIENT_ID` and `CWS_CLIENT_SECRET` when ready (I will treat them as secrets)."
+Prompt: "Paste `CWS_CLIENT_ID` and `CWS_CLIENT_SECRET` when ready (I will treat them as secrets)."
 
 ### 2.4 Generate Refresh Token (OAuth Playground)
 
-Tell user to open:
-- `https://developers.google.com/oauthplayground/`
+Open: `https://developers.google.com/oauthplayground/`
 
-User actions:
-1. Click the settings gear icon.
-2. Enable `Use your own OAuth credentials`.
-3. Paste `CWS_CLIENT_ID` and `CWS_CLIENT_SECRET`.
-4. In Step 1, enter scope:
-- `https://www.googleapis.com/auth/chromewebstore`
-5. Click `Authorize APIs`.
-6. Sign in with the same Google account that owns/publishes the extension.
-7. Click `Exchange authorization code for tokens`.
-8. Copy refresh token.
+- [ ] Click the settings gear icon → enable `Use your own OAuth credentials` → paste `CWS_CLIENT_ID` and `CWS_CLIENT_SECRET`
+- [ ] In Step 1, enter scope: `https://www.googleapis.com/auth/chromewebstore` → click `Authorize APIs`
+- [ ] Sign in with the account that owns/publishes the extension
+- [ ] Click `Exchange authorization code for tokens` → copy the refresh token as `CWS_REFRESH_TOKEN`
 
-Capture value:
-- `CWS_REFRESH_TOKEN`
-
-Agent prompt example:
-- "Paste `CWS_REFRESH_TOKEN` now. I will only place it in local secret storage/CI secrets."
+Prompt: "Paste `CWS_REFRESH_TOKEN` now. I will only place it in local secret storage/CI secrets."
 
 ### 2.5 Capture Store IDs
 
-Capture:
-- `CWS_EXTENSION_ID` (the extension item ID from store/developer listing URL)
-- `CWS_PUBLISHER_ID` (developer/publisher ID from Chrome Web Store developer account context)
+- `CWS_EXTENSION_ID` — item ID from the store/developer listing URL
+- `CWS_PUBLISHER_ID` — developer/publisher ID from Chrome Web Store Developer Dashboard
 
-Agent instruction:
-- If user is unsure, ask them to open the Chrome Web Store Developer Dashboard and copy IDs from item/account URLs or account details.
+If user is unsure, ask them to open the Developer Dashboard and copy IDs from item/account URLs or account details.
 
 ### 2.6 Credential Checklist
 
@@ -138,7 +92,7 @@ CWS_PUBLISHER_ID=
 CWS_EXTENSION_ID=
 ```
 
-Ensure real secret file path is gitignored.
+Ensure the real secret file path is gitignored.
 
 If using GitHub Actions, ask user if `gh` automation is desired.
 
@@ -149,70 +103,205 @@ gh --version
 gh auth status
 ```
 
-If `gh` auth is missing, tell user to run:
-- `gh auth login`
+If `gh` auth is missing, tell user to run `gh auth login`.
 
-Then implement a helper script that:
-- reads secret values from local env file
-- validates all required keys are present
-- supports `--dry-run`
-- masks values in dry-run output
-- uploads with `gh secret set ... --repo ...`
-- fails fast on missing keys/auth
+Implement the secret upload helper as `scripts/upload-secrets.sh` (full source below). Usage:
+
+```bash
+# Dry run (masks values)
+DRY_RUN=true bash scripts/upload-secrets.sh .env.local
+
+# Live upload to default repo
+bash scripts/upload-secrets.sh .env.local
+
+# Live upload to specific repo
+REPO=owner/repo bash scripts/upload-secrets.sh .env.local
+```
+
+### `scripts/upload-secrets.sh`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${1:-.env.local}"
+DRY_RUN="${DRY_RUN:-false}"
+REPO="${REPO:-}"   # e.g. owner/repo; falls back to gh default
+
+REQUIRED_KEYS=(CWS_CLIENT_ID CWS_CLIENT_SECRET CWS_REFRESH_TOKEN CWS_PUBLISHER_ID CWS_EXTENSION_ID)
+
+# Load env file
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: env file not found: $ENV_FILE" >&2; exit 1
+fi
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+# Validate all keys are present and non-empty
+for key in "${REQUIRED_KEYS[@]}"; do
+  val="${!key:-}"
+  if [[ -z "$val" ]]; then
+    echo "ERROR: missing required secret: $key" >&2; exit 1
+  fi
+done
+
+REPO_FLAG="${REPO:+--repo $REPO}"
+
+for key in "${REQUIRED_KEYS[@]}"; do
+  val="${!key}"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[dry-run] would set $key=***"
+  else
+    # shellcheck disable=SC2086
+    echo "$val" | gh secret set "$key" $REPO_FLAG
+    echo "Uploaded: $key"
+  fi
+done
+echo "Done."
+```
 
 If user declines `gh`, provide manual secret entry checklist for repository settings.
 
 ## Step 4: Release Workflow Blueprint (Version-Triggered)
 
-Design the CI workflow around this logic:
+### 4.1 Token Exchange
 
-1. Read local manifest version.
-2. Optionally compare with a secondary version file and fail on mismatch.
-3. Exchange refresh token for access token:
-- `POST https://oauth2.googleapis.com/token`
-4. Fetch CWS status:
-- `GET https://chromewebstore.googleapis.com/v2/publishers/<publisherId>/items/<extensionId>:fetchStatus`
-5. Extract current published version from:
-- `publishedItemRevisionStatus.distributionChannels[0].crxVersion`
-6. If local version == published version, skip publish.
-7. If version changed:
-- build package zip
-- upload zip:
-  `POST https://chromewebstore.googleapis.com/upload/v2/publishers/<publisherId>/items/<extensionId>:upload`
-- handle async upload state with polling when needed
-- publish:
-  `POST https://chromewebstore.googleapis.com/v2/publishers/<publisherId>/items/<extensionId>:publish`
+```bash
+ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+  -d "client_id=${CWS_CLIENT_ID}" \
+  -d "client_secret=${CWS_CLIENT_SECRET}" \
+  -d "refresh_token=${CWS_REFRESH_TOKEN}" \
+  -d "grant_type=refresh_token" \
+  | jq -r '.access_token')
+```
 
-Treat these publish states as successful submission:
-- `PENDING_REVIEW`
-- `PUBLISHED`
-- `PUBLISHED_TO_TESTERS`
-- `STAGED`
+### 4.2 Fetch Published Version
+
+```bash
+STATUS=$(curl -s \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "https://chromewebstore.googleapis.com/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_EXTENSION_ID}:fetchStatus")
+
+PUBLISHED_VERSION=$(echo "$STATUS" \
+  | jq -r '.publishedItemRevisionStatus.distributionChannels[0].crxVersion // empty')
+```
+
+### 4.3 Version Comparison and Publish
+
+```bash
+LOCAL_VERSION=$(jq -r '.version' "$MANIFEST_PATH")
+
+if [[ "$LOCAL_VERSION" == "$PUBLISHED_VERSION" ]]; then
+  echo "Version unchanged ($LOCAL_VERSION). Skipping publish."
+  exit 0
+fi
+
+echo "Version changed: $PUBLISHED_VERSION → $LOCAL_VERSION. Building and publishing..."
+
+# Build and package
+eval "$BUILD_CMD"
+eval "$ZIP_CMD"   # produces $ZIP_PATH
+
+# Upload
+curl -s -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/zip" \
+  --data-binary "@${ZIP_PATH}" \
+  "https://chromewebstore.googleapis.com/upload/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_EXTENSION_ID}:upload"
+
+# Publish
+curl -s -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "https://chromewebstore.googleapis.com/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_EXTENSION_ID}:publish"
+```
+
+Treat these states as successful submission: `PENDING_REVIEW`, `PUBLISHED`, `PUBLISHED_TO_TESTERS`, `STAGED`.
 
 ## Step 5: Submission Status Checker Blueprint
 
-Create a script dedicated to "what is the latest submission state?".
+Implement the status checker as `scripts/cws-status.sh` (full source below). Usage:
 
-Required behavior:
-- accepts env values (and optional `--env-file`)
-- optionally accepts `--manifest` for local version comparison
-- supports `--json`
-- calls token endpoint + `fetchStatus`
-- outputs normalized fields:
-  - `itemId`
-  - `localVersion`
-  - `publishedVersion`
-  - `publishedState`
-  - `submittedVersion`
-  - `submittedState`
-  - `upToDate`
-  - `pendingReview`
-- exits non-zero on auth/API/input errors
+```bash
+# Human-readable summary
+bash scripts/cws-status.sh --env-file .env.local --manifest src/manifest.json
 
-Helpful checks to include:
-- flag version mismatch between manifest and package metadata
-- show whether uploaded version is pending review but not yet published
-- print concise human summary when `--json` is not used
+# JSON output (for CI or jq piping)
+bash scripts/cws-status.sh --env-file .env.local --manifest src/manifest.json --json
+```
+
+### `scripts/cws-status.sh`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-.env.local}"
+MANIFEST="${MANIFEST:-}"
+JSON_OUTPUT="${JSON:-false}"
+
+# Parse flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file) ENV_FILE="$2"; shift 2 ;;
+    --manifest) MANIFEST="$2"; shift 2 ;;
+    --json)     JSON_OUTPUT=true; shift ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+# Token exchange
+ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+  -d "client_id=${CWS_CLIENT_ID}" \
+  -d "client_secret=${CWS_CLIENT_SECRET}" \
+  -d "refresh_token=${CWS_REFRESH_TOKEN}" \
+  -d "grant_type=refresh_token" \
+  | jq -r '.access_token')
+
+[[ -z "$ACCESS_TOKEN" || "$ACCESS_TOKEN" == "null" ]] && { echo "ERROR: token exchange failed" >&2; exit 1; }
+
+# Fetch status
+STATUS=$(curl -s \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "https://chromewebstore.googleapis.com/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_EXTENSION_ID}:fetchStatus")
+
+PUBLISHED_VERSION=$(echo "$STATUS" | jq -r '.publishedItemRevisionStatus.distributionChannels[0].crxVersion // empty')
+PUBLISHED_STATE=$(echo  "$STATUS" | jq -r '.publishedItemRevisionStatus.status // empty')
+SUBMITTED_VERSION=$(echo "$STATUS" | jq -r '.pendingItemRevisionStatus.crxVersion // empty')
+SUBMITTED_STATE=$(echo  "$STATUS" | jq -r '.pendingItemRevisionStatus.status // empty')
+LOCAL_VERSION=""
+if [[ -n "$MANIFEST" ]]; then
+  LOCAL_VERSION=$(jq -r '.version' "$MANIFEST")
+fi
+
+UP_TO_DATE="false"
+[[ -n "$LOCAL_VERSION" && "$LOCAL_VERSION" == "$PUBLISHED_VERSION" ]] && UP_TO_DATE="true"
+PENDING_REVIEW="false"
+[[ "$SUBMITTED_STATE" == "PENDING_REVIEW" ]] && PENDING_REVIEW="true"
+
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+  jq -n \
+    --arg itemId        "$CWS_EXTENSION_ID" \
+    --arg localVersion  "$LOCAL_VERSION" \
+    --arg publishedVersion "$PUBLISHED_VERSION" \
+    --arg publishedState   "$PUBLISHED_STATE" \
+    --arg submittedVersion "$SUBMITTED_VERSION" \
+    --arg submittedState   "$SUBMITTED_STATE" \
+    --argjson upToDate     "$UP_TO_DATE" \
+    --argjson pendingReview "$PENDING_REVIEW" \
+    '{itemId:$itemId,localVersion:$localVersion,publishedVersion:$publishedVersion,
+      publishedState:$publishedState,submittedVersion:$submittedVersion,
+      submittedState:$submittedState,upToDate:$upToDate,pendingReview:$pendingReview}'
+else
+  echo "Extension : $CWS_EXTENSION_ID"
+  [[ -n "$LOCAL_VERSION" ]] && echo "Local ver  : $LOCAL_VERSION"
+  echo "Published  : ${PUBLISHED_VERSION} (${PUBLISHED_STATE})"
+  [[ -n "$SUBMITTED_VERSION" ]] && echo "Submitted  : ${SUBMITTED_VERSION} (${SUBMITTED_STATE})"
+  echo "Up-to-date : $UP_TO_DATE  |  Pending review: $PENDING_REVIEW"
+fi
+```
 
 ## Step 6: Guided Verification Flow
 
@@ -221,38 +310,26 @@ Run this with the user:
 1. Confirm status checker runs successfully before release.
 2. Bump extension version (patch) in all version sources.
 3. Push branch and trigger workflow.
-4. Confirm workflow either:
-- skips (if no version change), or
-- uploads and submits publish.
-5. Re-run status checker:
-- expect `PENDING_REVIEW` first in many cases
-- later expect published channel to match local version
+4. Confirm workflow either skips (no version change) or uploads and submits.
+5. Re-run status checker — expect `PENDING_REVIEW` first, then published channel matching local version.
 
-## Troubleshooting Script (What Agent Should Say)
+## Troubleshooting
 
-- `invalid_grant`:
-- likely wrong/expired refresh token, wrong OAuth client, or wrong account
-- `403` from CWS endpoint:
-- account lacks publisher permissions for that extension
-- workflow no-op:
-- local version equals published version by design
-- upload failure:
-- inspect API response and packaged zip structure/manifest validity
-- version mismatch guard failure:
-- align all declared version files before publishing
+| Symptom | Likely cause |
+|---|---|
+| `invalid_grant` | Wrong/expired refresh token, wrong OAuth client, or wrong account |
+| `403` from CWS endpoint | Account lacks publisher permissions for that extension |
+| Workflow no-op | Local version equals published version by design |
+| Upload failure | Inspect API response and packaged zip structure/manifest validity |
+| Version mismatch guard failure | Align all declared version files before publishing |
 
 ## Practical Links (Share During Guidance)
 
-- Chrome Web Store API overview:
-`https://developer.chrome.com/docs/webstore/using-api`
-- Publish endpoint:
-`https://developer.chrome.com/docs/webstore/publish`
-- OAuth Playground:
-`https://developers.google.com/oauthplayground/`
-- API enablement page:
-`https://console.cloud.google.com/apis/library/chromewebstore.googleapis.com`
-- Credentials page:
-`https://console.cloud.google.com/apis/credentials`
+- Chrome Web Store API overview: `https://developer.chrome.com/docs/webstore/using-api`
+- Publish endpoint: `https://developer.chrome.com/docs/webstore/publish`
+- OAuth Playground: `https://developers.google.com/oauthplayground/`
+- API enablement page: `https://console.cloud.google.com/apis/library/chromewebstore.googleapis.com`
+- Credentials page: `https://console.cloud.google.com/apis/credentials`
 
 ## Guardrails
 

--- a/skills/deslop/SKILL.md
+++ b/skills/deslop/SKILL.md
@@ -1,16 +1,61 @@
 ---
 name: deslop
-description: Remove AI-generated code slop from the current branch. Use after writing code to clean up unnecessary comments, defensive checks, and inconsistent style.
+description: Remove AI-generated code slop from the current branch. Use after writing code to clean up unnecessary comments, defensive checks, and inconsistent style — also useful when asked to 'clean up generated code', 'remove AI boilerplate', 'remove AI artifacts', 'refactor AI code', or 'remove redundant error handling'. Actions include stripping unhelpful inline comments, removing abnormal try/catch blocks, eliminating `any` casts, simplifying verbose patterns, and standardising naming conventions to match the rest of the codebase.
 ---
 
 # Remove AI code slop
 
 Check the diff against main, and remove all AI generated slop introduced in this branch.
 
+## Step 1 — Review the diff
+
+```bash
+git diff main...HEAD
+```
+
+## Step 2 — Identify and remove slop
+
 This includes:
 - Extra comments that a human wouldn't add or is inconsistent with the rest of the file
 - Extra defensive checks or try/catch blocks that are abnormal for that area of the codebase (especially if called by trusted / validated codepaths)
-- Casts to any to get around type issues
+- Casts to `any` to get around type issues
+- Verbose or over-engineered patterns where a simpler form is idiomatic in this codebase
 - Any other style that is inconsistent with the file
 
-Report at the end with only a 1-3 sentence summary of what you changed
+### Before / after examples
+
+**Unnecessary comment slop:**
+```ts
+// Before
+// Check if the user exists before proceeding
+const user = await getUser(id);
+
+// After
+const user = await getUser(id);
+```
+
+**Abnormal defensive check slop:**
+```ts
+// Before (in a trusted internal codepath that already validates input)
+if (!id || typeof id !== 'string') {
+  throw new Error('Invalid id');
+}
+const user = await getUser(id);
+
+// After
+const user = await getUser(id);
+```
+
+## Step 3 — Validate
+
+Run the project's tests or type-checker after making changes to confirm nothing is broken:
+
+```bash
+# examples — use whatever is appropriate for this project
+npm test
+npx tsc --noEmit
+```
+
+## Step 4 — Report
+
+Report at the end with only a 1-3 sentence summary of what you changed.

--- a/skills/favicon/SKILL.md
+++ b/skills/favicon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: favicon
-description: Generate a complete set of favicons from a source image and update HTML. Use when setting up favicons for a web project.
+description: Generates a complete set of favicons from a source image, including favicon.ico (16×16, 32×32, 48×48), apple-touch-icon (180×180), PWA manifest icons (192×192, 512×512), favicon-96x96.png, and optionally favicon.svg, then creates or updates site.webmanifest and injects the appropriate link tags into the project's HTML or layout file. Use when setting up or replacing favicons, a site icon, browser icon, or app icon for a web project — including requests involving favicon.ico, apple-touch-icon, PWA icons, or web app manifest icons across Rails, Next.js, static HTML, and other frameworks.
 argument-hint: [path to source image]
 ---
 
@@ -27,40 +27,38 @@ Note whether the source is an SVG file - if so, it will also be copied as `favic
 
 ## Step 2: Detect Project Type and Static Assets Directory
 
-Detect the project type and determine where static assets should be placed. Check in this order:
+The general pattern is: look for a framework config file, then use the corresponding static directory. Check in this order:
 
-| Framework | Detection | Static Assets Directory |
-|-----------|-----------|------------------------|
-| **Rails** | `config/routes.rb` exists | `public/` |
-| **Next.js** | `next.config.*` exists | `public/` |
-| **Gatsby** | `gatsby-config.*` exists | `static/` |
-| **SvelteKit** | `svelte.config.*` exists | `static/` |
-| **Astro** | `astro.config.*` exists | `public/` |
-| **Hugo** | `hugo.toml` or `config.toml` with Hugo markers | `static/` |
-| **Jekyll** | `_config.yml` with Jekyll markers | Root directory (same as `index.html`) |
-| **Vite** | `vite.config.*` exists | `public/` |
-| **Create React App** | `package.json` has `react-scripts` dependency | `public/` |
-| **Vue CLI** | `vue.config.*` exists | `public/` |
-| **Angular** | `angular.json` exists | `src/assets/` |
-| **Eleventy** | `.eleventy.js` or `eleventy.config.*` exists | Check `_site` output or root |
+| Framework | Config File | Static Assets Directory |
+|-----------|-------------|------------------------|
+| **Rails** | `config/routes.rb` | `public/` |
+| **Next.js** | `next.config.*` | `public/` |
+| **Gatsby** | `gatsby-config.*` | `static/` |
+| **SvelteKit** | `svelte.config.*` | `static/` |
+| **Astro** | `astro.config.*` | `public/` |
+| **Hugo** | `hugo.toml` / `config.toml` | `static/` |
+| **Jekyll** | `_config.yml` | Root (same as `index.html`) |
+| **Vite** | `vite.config.*` | `public/` |
+| **Create React App** | `react-scripts` in `package.json` | `public/` |
+| **Vue CLI** | `vue.config.*` | `public/` |
+| **Angular** | `angular.json` | `src/assets/` |
+| **Eleventy** | `.eleventy.js` / `eleventy.config.*` | Check `_site` output or root |
 | **Static HTML** | `index.html` in root | Same directory as `index.html` |
 
 **Important**: If existing favicon files are found (e.g., `favicon.ico`, `apple-touch-icon.png`), use their location as the target directory regardless of framework detection.
 
 Report the detected project type and the static assets directory that will be used.
 
-**When in doubt, ask**: If you are not 100% confident about where static assets should be placed (e.g., ambiguous project structure, multiple potential locations, unfamiliar framework), use `AskUserQuestionTool` to confirm the target directory before proceeding. It's better to ask than to put files in the wrong place.
+**When in doubt, ask**: If you are not 100% confident about where static assets should be placed, use `AskUserQuestionTool` to confirm the target directory before proceeding.
 
 ## Step 3: Determine App Name
 
 Find the app name from these sources (in priority order):
 
-1. **Existing `site.webmanifest`** - Check the detected static assets directory for an existing manifest and extract the `name` field
-2. **`package.json`** - Extract the `name` field if it exists
-3. **Rails `config/application.rb`** - Extract the module name (e.g., `module MyApp` → "MyApp")
-4. **Directory name** - Use the current working directory name as fallback
-
-Convert the name to title case if needed (e.g., "my-app" → "My App").
+1. **Existing `site.webmanifest`** — extract the `name` field
+2. **`package.json`** — extract the `name` field
+3. **Rails `config/application.rb`** — extract the module name (e.g., `module MyApp` → "MyApp")
+4. **Directory name** — use the current working directory name as fallback
 
 ## Step 4: Ensure Static Assets Directory Exists
 
@@ -101,7 +99,6 @@ magick "$1" -resize 512x512 -background none -alpha on [STATIC_DIR]/web-app-mani
 ```
 
 ### favicon.svg (only if source is SVG)
-If the source file has a `.svg` extension, copy it:
 ```bash
 cp "$1" [STATIC_DIR]/favicon.svg
 ```
@@ -134,18 +131,18 @@ Create or update `[STATIC_DIR]/site.webmanifest` with this content (substitute t
 }
 ```
 
-If `site.webmanifest` already exists in the static directory, preserve the existing `theme_color`, `background_color`, and `display` values while updating the `name`, `short_name`, and `icons` array.
+If `site.webmanifest` already exists, preserve the existing `theme_color`, `background_color`, and `display` values while updating `name`, `short_name`, and the `icons` array.
 
 ## Step 7: Update HTML/Layout Files
 
-Based on the detected project type, update the appropriate file. Adjust the `href` paths based on where the static assets directory is relative to the web root:
-- If static files are in `public/` or `static/` and served from root → use `/favicon.ico`
-- If static files are in `src/assets/` → use `/assets/favicon.ico`
-- If static files are in the same directory as HTML → use `./favicon.ico` or just `favicon.ico`
+Adjust `href` paths based on how the static assets directory maps to the web root:
+- `public/` or `static/` served from root → `/favicon.ico`
+- `src/assets/` → `/assets/favicon.ico`
+- Same directory as HTML → `favicon.ico`
 
-### For Rails Projects
+### Standard HTML favicon tags
 
-Edit `app/views/layouts/application.html.erb`. Find the `<head>` section and add/replace favicon-related tags with:
+Used for Rails, Static HTML, Jekyll, Hugo, Eleventy, Gatsby, SvelteKit, and other HTML-based frameworks. Place near the top of `<head>` (after `<meta charset>` and `<meta name="viewport">` if present). Remove any existing `<link rel="icon"`, `<link rel="shortcut icon"`, `<link rel="apple-touch-icon"`, or `<link rel="manifest"` tags first.
 
 ```html
 <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
@@ -156,14 +153,17 @@ Edit `app/views/layouts/application.html.erb`. Find the `<head>` section and add
 <link rel="manifest" href="/site.webmanifest" />
 ```
 
-**Important**:
-- If the source was NOT an SVG, omit the `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` line
-- Remove any existing `<link rel="icon"`, `<link rel="shortcut icon"`, `<link rel="apple-touch-icon"`, or `<link rel="manifest"` tags before adding the new ones
-- Place these tags near the top of the `<head>` section, after `<meta charset>` and `<meta name="viewport">` if present
+**If the source was NOT an SVG**, omit the `<link rel="icon" type="image/svg+xml" ...>` line.
+
+| Project Type | File to edit |
+|---|---|
+| **Rails** | `app/views/layouts/application.html.erb` |
+| **Static HTML** | Detected `index.html` |
+| **Jekyll / Hugo / Eleventy / Gatsby / SvelteKit** | Theme or layout template containing `<head>` |
 
 ### For Next.js Projects
 
-Edit the detected layout file (`app/layout.tsx` or `src/app/layout.tsx`). Update or add the `metadata` export to include icons configuration:
+Edit the detected layout file (`app/layout.tsx` or `src/app/layout.tsx`). Update or add the `metadata` export:
 
 ```typescript
 export const metadata: Metadata = {
@@ -184,27 +184,11 @@ export const metadata: Metadata = {
 };
 ```
 
-**Important**:
-- If the source was NOT an SVG, omit the `{ url: '/favicon.svg', type: 'image/svg+xml' }` entry from the icon array
-- If metadata export doesn't exist, create it with just the icons-related fields
-- If metadata export exists, merge the icons configuration with existing fields
-
-### For Static HTML Projects
-
-Edit the detected `index.html` file. Add the same HTML as Rails within the `<head>` section.
+**If the source was NOT an SVG**, omit the `{ url: '/favicon.svg', type: 'image/svg+xml' }` entry. If the metadata export doesn't exist, create it with just the icons-related fields; if it exists, merge the icons configuration with existing fields.
 
 ### If No Project Detected
 
-Skip HTML updates and inform the user they need to manually add the following to their HTML `<head>`:
-
-```html
-<link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-<link rel="shortcut icon" href="/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-<meta name="apple-mobile-web-app-title" content="[APP_NAME]" />
-<link rel="manifest" href="/site.webmanifest" />
-```
+Skip HTML updates and inform the user to manually add the standard HTML favicon tags above to their `<head>`.
 
 ## Step 8: Summary
 

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -1,35 +1,9 @@
 ---
 name: find-skills
-description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+description: Helps users discover and install agent skills by searching skill catalogs, browsing available extensions, comparing skill options, and guiding the installation process. Use when users ask "how do I do X", "find a skill for X", "is there a skill that can...", want to compare or browse installable extensions, or express interest in extending agent capabilities with specialized tools, templates, or workflows.
 ---
 
 # Find Skills
-
-This skill helps you discover and install skills from the open agent skills ecosystem.
-
-## When to Use This Skill
-
-Use this skill when the user:
-
-- Asks "how do I do X" where X might be a common task with an existing skill
-- Says "find a skill for X" or "is there a skill for X"
-- Asks "can you do X" where X is a specialized capability
-- Expresses interest in extending agent capabilities
-- Wants to search for tools, templates, or workflows
-- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
-
-## What is the Skills CLI?
-
-The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
-
-**Key commands:**
-
-- `npx skills find [query]` - Search for skills interactively or by keyword
-- `npx skills add <package>` - Install a skill from GitHub or other sources
-- `npx skills check` - Check for skill updates
-- `npx skills update` - Update all installed skills
-
-**Browse skills at:** https://skills.sh/
 
 ## How to Help Users Find Skills
 
@@ -64,6 +38,11 @@ vercel-labs/agent-skills@vercel-react-best-practices
 └ https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices
 ```
 
+**Search tips:**
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
 ### Step 3: Present Options to the User
 
 When you find relevant skills, present them to the user with:
@@ -96,23 +75,7 @@ The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts
 
 ## Common Skill Categories
 
-When searching, consider these common categories:
-
-| Category        | Example Queries                          |
-| --------------- | ---------------------------------------- |
-| Web Development | react, nextjs, typescript, css, tailwind |
-| Testing         | testing, jest, playwright, e2e           |
-| DevOps          | deploy, docker, kubernetes, ci-cd        |
-| Documentation   | docs, readme, changelog, api-docs        |
-| Code Quality    | review, lint, refactor, best-practices   |
-| Design          | ui, ux, design-system, accessibility     |
-| Productivity    | workflow, automation, git                |
-
-## Tips for Effective Searches
-
-1. **Use specific keywords**: "react testing" is better than just "testing"
-2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
-3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+See [CATEGORIES.md](./CATEGORIES.md) for a full reference table of common categories and example search queries (web development, testing, DevOps, documentation, code quality, design, productivity, and more).
 
 ## When No Skills Are Found
 

--- a/skills/knip/SKILL.md
+++ b/skills/knip/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knip
-description: Run knip to find and remove unused files, dependencies, and exports. Use for cleaning up dead code and unused dependencies.
+description: Run knip to find and remove unused files, dependencies, and exports. Use when cleaning up dead code, pruning unused dependencies, removing orphaned files, auditing dependencies, or finding unused imports and exports across a project.
 ---
 
 # Knip Code Cleanup
@@ -14,7 +14,7 @@ Run knip to find and remove unused files, dependencies, and exports from this co
    - If it fails or is very slow, check if `knip` is in package.json devDependencies
    - If not installed locally, install with `npm install -D knip` (or pnpm/yarn/bun equivalent based on lockfile present)
 
-2. Knip does NOT remove unused imports/variables inside files — that's a linter's job. Knip finds unused files, dependencies, and exports across the project.
+2. Knip targets unused files, dependencies, and exports — not unused imports/variables inside files (use a linter for that).
 
 ## Workflow
 
@@ -61,15 +61,13 @@ Re-run knip after each batch of fixes. Removing unused files often exposes newly
 
 ## Configuration Best Practices
 
-When reviewing or creating a knip config, follow these rules:
-
-- **Never use `ignore` patterns** — `ignore` hides real issues and should almost never be used. Always prefer specific solutions. Other `ignore*` options (like `ignoreDependencies`, `ignoreExportsUsedInFile`) are fine because they target specific issue types.
-- **Many unused exported types?** Add `ignoreExportsUsedInFile: { interface: true, type: true }` — this handles the common case of types only used in the same file. Prefer this over broader ignore options.
-- **Remove redundant patterns** — Knip already respects `.gitignore`, so ignoring `node_modules`, `dist`, `build`, `.git` is redundant.
-- **Remove entry patterns covered by defaults** — Auto-detected plugins already add standard entry points. Don't duplicate them.
-- **Config files showing as unused** (e.g. `vite.config.ts`) — Enable or disable the corresponding plugin explicitly rather than ignoring the file.
-- **Dependencies matching Node.js builtins** (e.g. `buffer`, `process`) — Add to `ignoreDependencies`.
-- **Unresolved imports from path aliases** — Add `paths` to knip config (uses tsconfig.json semantics).
+- **Never use `ignore` patterns** — hides real issues; always prefer specific solutions. Other `ignore*` options (`ignoreDependencies`, `ignoreExportsUsedInFile`) are fine.
+- **Many unused exported types?** Add `ignoreExportsUsedInFile: { interface: true, type: true }` to handle types used only in the same file.
+- **Remove redundant patterns** — knip already respects `.gitignore`; don't re-ignore `node_modules`, `dist`, `build`, `.git`.
+- **Remove duplicate entry patterns** — auto-detected plugins already add standard entry points.
+- **Config files showing as unused** (e.g. `vite.config.ts`) — enable/disable the corresponding plugin explicitly.
+- **Dependencies matching Node.js builtins** (e.g. `buffer`, `process`) — add to `ignoreDependencies`.
+- **Unresolved path alias imports** — add `paths` to knip config (uses tsconfig.json semantics).
 
 ## Production Mode
 
@@ -84,16 +82,16 @@ This excludes test files, config files, and other non-production entry points. D
 ## Cleanup Confidence Levels
 
 ### Auto-delete (high confidence):
-- Unused exports that are clearly internal (not part of public API)
+- Unused exports clearly internal (not part of public API)
 - Unused type exports
 - Unused dependencies (remove from package.json)
-- Unused files that are clearly orphaned (not entry points, not config files)
+- Clearly orphaned files (not entry points, not config files)
 
 ### Ask first (needs clarification):
 - Files that might be entry points or dynamically imported
-- Exports that might be part of a public API (index.ts, lib exports)
+- Exports that might be part of a public API (`index.ts`, lib exports)
 - Dependencies that might be used via CLI or peer dependencies
-- Anything in paths like `src/index`, `lib/`, or files with "public" or "api" in the name
+- Files in paths like `src/index`, `lib/`, or with "public"/"api" in the name
 
 Use the AskUserQuestion tool to clarify before deleting these.
 
@@ -142,4 +140,4 @@ npx knip --reporter json
 
 - Watch for monorepo setups — may need `--workspace` flag
 - Some frameworks need plugins enabled in config
-- Knip does not handle unused imports/variables inside files — use ESLint or Biome for that
+- Use ESLint or Biome for unused imports/variables inside files

--- a/skills/playwriter/SKILL.md
+++ b/skills/playwriter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwriter
-description: Control the user's currently open Chrome tab through the Playwriter CLI (no new browser launch). Use when you need to inspect live UI state, run scripted browser actions, capture console output, or reproduce frontend issues directly in the user's tab.
+description: Control the user's currently open Chrome tab through the Playwriter CLI (no new browser launch). Use when you need to debug, automate, or test in browser — including DOM inspection, clicking elements, taking screenshots, capturing console output, inspecting live UI state, or reproducing frontend issues directly in the user's active tab.
 ---
 
 # Playwriter
@@ -45,8 +45,26 @@ playwriter -s <session> -e "console.log(await accessibilitySnapshot({ page }))"
 ```
 
 3. Execute targeted actions (click/type/hover/fetch/evaluate).
-4. Pull logs and structured state via `page.evaluate`.
-5. Summarize findings with exact IDs, timestamps, and observed state transitions.
+
+4. Validate the action succeeded — check for expected element state or console output before proceeding:
+
+```bash
+playwriter -s <session> -e "console.log(await page.locator('<expected-selector>').isVisible());"
+```
+
+5. If an action may be timing-sensitive, use a wait → verify → retry pattern:
+
+```bash
+playwriter -s <session> -e "
+  await page.waitForTimeout(500);
+  const visible = await page.locator('<expected-selector>').isVisible();
+  console.log('visible:', visible);
+  // Retry or proceed based on result
+"
+```
+
+6. Pull logs and structured state via `page.evaluate`.
+7. Summarize findings with exact IDs, timestamps, and observed state transitions.
 
 ## Useful Commands
 

--- a/skills/rams/SKILL.md
+++ b/skills/rams/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rams
-description: Run accessibility and visual design review on components. Use when reviewing UI code for WCAG compliance and design issues.
+description: Run accessibility and visual design review on components, checking color contrast ratios, verifying ARIA labels, auditing keyboard navigation, and reviewing focus states. Use when reviewing UI code for WCAG compliance, a11y issues, ADA compliance, screen reader support, contrast ratio problems, keyboard accessible interactions, or general design issues.
 ---
 
 # Rams Design Review
@@ -95,11 +95,11 @@ Score: XX/100
 
 ---
 
-## Guidelines
+## Workflow
 
-1. Read the file(s) first before making assessments
-2. Be specific with line numbers and code snippets
-3. Provide fixes, not just problems
-4. Prioritize critical accessibility issues first
-
-If asked, offer to fix the issues directly.
+1. **Read** — Read the file(s) in full before making any assessments.
+2. **Identify** — Audit for all accessibility and visual design issues across severity tiers.
+3. **Report** — Output findings using the format above, with specific line numbers, code snippets, and fixes. Prioritize critical accessibility issues first.
+4. **Fix** *(if asked)* — Apply fixes directly to the file(s).
+5. **Re-review** — After applying fixes, re-read the file and re-run all checks to confirm every issue is resolved.
+6. **Confirm** — Report that no regressions or new issues were introduced before closing the review.

--- a/skills/react-doctor/SKILL.md
+++ b/skills/react-doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-doctor
-description: Diagnose and fix React codebase health issues. Use when reviewing React code, fixing performance problems, auditing security, or improving code quality.
+description: Diagnoses and fixes React codebase health issues by running automated analysis across security, performance, correctness, and architecture dimensions. Use when reviewing React components, hooks, or .jsx/.tsx files; identifying unnecessary re-renders, memory leaks, or component lifecycle issues; auditing useState/useEffect misuse, missing cleanup, or hardcoded secrets; improving bundle size, accessibility, or Next.js server patterns; or generating a 0-100 health score with prioritized, actionable diagnostics.
 version: 1.0.0
 ---
 

--- a/skills/sentry/SKILL.md
+++ b/skills/sentry/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: sentry
-description: Sentry error monitoring and performance tracing patterns for Next.js applications.
+description: Configures and applies Sentry SDK patterns for error monitoring, performance tracing, and structured logging in Next.js applications. Use when working with Sentry setup, error tracking, crash reporting, exception handling, APM, or observability in Next.js — including tasks like "track errors in production", "debug production issues", "monitor app performance", "set up crash reporting", "add performance spans", or "configure the Sentry SDK". Covers SDK initialization across client/server/edge runtimes, captureException usage, custom span creation for UI actions and API calls, consoleLoggingIntegration, and structured logger output.
 ---
 
 # Sentry Integration
 
 Guidelines for using Sentry for error monitoring and performance tracing.
+
+## Setup Workflow
+
+Follow this sequence when initializing Sentry in a Next.js project:
+
+1. **Create config files** — `sentry.client.config.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts`
+2. **Add DSN** — set `NEXT_PUBLIC_SENTRY_DSN` in environment variables and call `Sentry.init()`
+3. **Verify** — send a test event with `Sentry.captureMessage("Test")` and confirm it appears in the Sentry dashboard
 
 ## Exception Catching
 
@@ -81,6 +89,15 @@ Sentry.init({
     Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
 });
+```
+
+### Verification
+
+After initialization, confirm Sentry is capturing events correctly:
+
+```javascript
+// Send a test event and check the Sentry dashboard
+Sentry.captureMessage("Test: Sentry initialized successfully");
 ```
 
 ## Structured Logging

--- a/skills/simplify/SKILL.md
+++ b/skills/simplify/SKILL.md
@@ -1,51 +1,84 @@
 ---
 name: simplify
-description: Simplify and refine recently modified code for clarity and consistency. Use after writing code to improve readability without changing functionality.
+description: Simplifies and refines recently modified code by renaming variables for clarity, extracting repeated logic into functions, simplifying conditionals, removing redundant abstractions, and improving formatting — all without changing functionality. Use when asked to clean up, refactor, polish, tidy up, or make code more readable after writing or modifying it.
 ---
 
-You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior. You prioritize readable, explicit code over overly compact solutions. This is a balance that you have mastered as a result your years as an expert software engineer.
-
-You will analyze recently modified code and apply refinements that:
+Analyze recently modified code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Follow the established coding standards from http://CLAUDE.md including:
+2. **Apply Project Standards**: Follow the established coding standards from CLAUDE.md including:
 
-- Use ES modules with proper import sorting and extensions
-- Prefer `function` keyword over arrow functions
-- Use explicit return type annotations for top-level functions
-- Follow proper React component patterns with explicit Props types
-- Use proper error handling patterns (avoid try/catch when possible)
-- Maintain consistent naming conventions
+   - Use ES modules with proper import sorting and extensions
+   - Prefer `function` keyword over arrow functions
+   - Use explicit return type annotations for top-level functions
+   - Follow proper React component patterns with explicit Props types
+   - Use proper error handling patterns (avoid try/catch when possible)
+   - Maintain consistent naming conventions
 
 3. **Enhance Clarity**: Simplify code structure by:
 
-- Reducing unnecessary complexity and nesting
-- Eliminating redundant code and abstractions
-- Improving readability through clear variable and function names
-- Consolidating related logic
-- Removing unnecessary comments that describe obvious code
-- IMPORTANT: Avoid nested ternary operators - prefer switch statements or if/else chains for multiple conditions
-- Choose clarity over brevity - explicit code is often better than overly compact code
+   - Renaming unclear variables and functions for self-documenting intent
+   - Extracting repeated logic into named functions
+   - Reducing unnecessary complexity and nesting
+   - Eliminating redundant code and abstractions
+   - Consolidating related logic
+   - Removing unnecessary comments that describe obvious code
+   - IMPORTANT: Avoid nested ternary operators — prefer switch statements or if/else chains for multiple conditions
 
-4. **Maintain Balance**: Avoid over-simplification that could:
+   **Example — variable renaming:**
+   ```ts
+   // Before
+   const d = new Date();
+   const x = users.filter(u => u.a === true);
 
-- Reduce code clarity or maintainability
-- Create overly clever solutions that are hard to understand
-- Combine too many concerns into single functions or components
-- Remove helpful abstractions that improve code organization
-- Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
-- Make the code harder to debug or extend
+   // After
+   const today = new Date();
+   const activeUsers = users.filter(u => u.isActive === true);
+   ```
+
+   **Example — function extraction:**
+   ```ts
+   // Before
+   const result = items.map(i => ({ id: i.id, label: i.name.trim().toLowerCase(), active: i.status === 'enabled' }));
+
+   // After
+   function normaliseItem(item: Item): NormalisedItem {
+     return { id: item.id, label: item.name.trim().toLowerCase(), active: item.status === 'enabled' };
+   }
+   const result = items.map(normaliseItem);
+   ```
+
+   **Example — nested ternary → switch:**
+   ```ts
+   // Before
+   const label = status === 'active' ? 'Active' : status === 'pending' ? 'Pending' : 'Unknown';
+
+   // After
+   function getLabel(status: string): string {
+     switch (status) {
+       case 'active': return 'Active';
+       case 'pending': return 'Pending';
+       default: return 'Unknown';
+     }
+   }
+   ```
+
+4. **Maintain Balance**: Avoid these anti-patterns:
+
+   - Overly clever solutions that sacrifice readability
+   - Combining too many concerns into a single function or component
+   - Removing helpful abstractions that aid organization
+   - Prioritizing fewer lines over clarity (e.g., dense one-liners, nested ternaries)
+   - Making code harder to debug or extend
 
 5. **Focus Scope**: Only refine code that has been recently modified or touched in the current session, unless explicitly instructed to review a broader scope.
 
-Your refinement process:
+## Refinement Process
 
 1. Identify the recently modified code sections
-2. Analyze for opportunities to improve elegance and consistency
-3. Apply project-specific best practices and coding standards
-4. Ensure all functionality remains unchanged
-5. Verify the refined code is simpler and more maintainable
+2. Analyze for opportunities to improve clarity and consistency
+3. Apply project-specific best practices and coding standards from CLAUDE.md
+4. Refactor incrementally — rename variables, extract functions, simplify conditionals
+5. **Validate that functionality is preserved**: run `npm test` (or the project's test command), or manually execute the changed function with known inputs and verify the output matches the pre-refactor behaviour. If any test fails, identify the specific change that caused the failure by reverting one change at a time, then attempt a narrower refinement or skip that particular improvement
 6. Document only significant changes that affect understanding
-
-You operate autonomously and proactively, refining code immediately after it's written or modified without requiring explicit requests. Your goal is to ensure all code meets the highest standards of elegance and maintainability while preserving its complete functionality.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+description: Guide for creating effective skills—covering writing YAML frontmatter, defining description fields, structuring skill content sections, and organizing bundled resources (scripts, references, assets). Use when users want to create a new skill, update an existing skill, write a SKILL.md file, build a skill template, work with a skill file, or extend Claude's capabilities with specialized knowledge, workflows, or tool integrations.
 license: Complete terms in LICENSE.txt
 ---
 
@@ -8,45 +8,7 @@ license: Complete terms in LICENSE.txt
 
 This skill provides guidance for creating effective skills.
 
-## About Skills
-
-Skills are modular, self-contained packages that extend Claude's capabilities by providing
-specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
-domains or tasks—they transform Claude from a general-purpose agent into a specialized agent
-equipped with procedural knowledge that no model can fully possess.
-
-### What Skills Provide
-
-1. Specialized workflows - Multi-step procedures for specific domains
-2. Tool integrations - Instructions for working with specific file formats or APIs
-3. Domain expertise - Company-specific knowledge, schemas, business logic
-4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
-
-## Core Principles
-
-### Concise is Key
-
-The context window is a public good. Skills share the context window with everything else Claude needs: system prompt, conversation history, other Skills' metadata, and the actual user request.
-
-**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have. Challenge each piece of information: "Does Claude really need this explanation?" and "Does this paragraph justify its token cost?"
-
-Prefer concise examples over verbose explanations.
-
-### Set Appropriate Degrees of Freedom
-
-Match the level of specificity to the task's fragility and variability:
-
-**High freedom (text-based instructions)**: Use when multiple approaches are valid, decisions depend on context, or heuristics guide the approach.
-
-**Medium freedom (pseudocode or scripts with parameters)**: Use when a preferred pattern exists, some variation is acceptable, or configuration affects behavior.
-
-**Low freedom (specific scripts, few parameters)**: Use when operations are fragile and error-prone, consistency is critical, or a specific sequence must be followed.
-
-Think of Claude as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
-
-### Anatomy of a Skill
-
-Every skill consists of a required SKILL.md file and optional bundled resources:
+## Skill Structure
 
 ```
 skill-name/
@@ -57,151 +19,68 @@ skill-name/
 │   └── Markdown instructions (required)
 └── Bundled Resources (optional)
     ├── scripts/          - Executable code (Python/Bash/etc.)
-    ├── references/       - Documentation intended to be loaded into context as needed
+    ├── references/       - Documentation loaded into context as needed
     └── assets/           - Files used in output (templates, icons, fonts, etc.)
 ```
 
-#### SKILL.md (required)
+## Core Principles
 
-Every SKILL.md consists of:
+- **Concise is key**: Only add context Claude doesn't already have. Prefer concise examples over verbose explanations.
+- **Progressive disclosure**: Metadata always in context (~100 words); SKILL.md body loads when triggered (<5k words, under 500 lines); bundled resources load as needed.
+- **Set appropriate degrees of freedom**: Use text instructions for flexible tasks, pseudocode for tasks with a preferred pattern, and specific scripts for fragile or deterministic operations.
 
-- **Frontmatter** (YAML): Contains `name` and `description` fields. These are the only fields that Claude reads to determine when the skill gets used, thus it is very important to be clear and comprehensive in describing what the skill is, and when it should be used.
-- **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
+Keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details into separate reference files.
 
-#### Bundled Resources (optional)
+## Anatomy of a Skill
 
-##### Scripts (`scripts/`)
+### SKILL.md (required)
 
-Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+- **Frontmatter** (YAML): Contains `name` and `description`. These are the only fields Claude reads to determine when the skill triggers—be clear and comprehensive.
+- **Body** (Markdown): Instructions loaded only after the skill triggers.
 
-- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
+### Bundled Resources (optional)
+
+#### Scripts (`scripts/`)
+
+Executable code for tasks requiring deterministic reliability or repeated rewriting.
+
+- **When to include**: When the same code is rewritten repeatedly or deterministic reliability is needed
 - **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
 - **Benefits**: Token efficient, deterministic, may be executed without loading into context
-- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
 
-##### References (`references/`)
+#### References (`references/`)
 
-Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
+Documentation loaded as needed into context to inform Claude's process.
 
-- **When to include**: For documentation that Claude should reference while working
-- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
-- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
-- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
+- **When to include**: For documentation Claude should reference while working
+- **Examples**: `references/schema.md` for database schemas, `references/api_docs.md` for API specs, `references/policies.md` for company policies
 - **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
-- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Move detailed reference material, schemas, and examples to references files to keep SKILL.md lean.
 
-##### Assets (`assets/`)
+#### Assets (`assets/`)
 
-Files not intended to be loaded into context, but rather used within the output Claude produces.
+Files used in Claude's output, not loaded into context.
 
-- **When to include**: When the skill needs files that will be used in the final output
-- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
-- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
-- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
+- **When to include**: When the skill needs files used in the final output
+- **Examples**: `assets/logo.png`, `assets/slides.pptx`, `assets/frontend-template/`
 
-#### What to Not Include in a Skill
+#### What to Not Include
 
-A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:
+Do NOT create extraneous documentation or auxiliary files:
 
-- README.md
-- INSTALLATION_GUIDE.md
-- QUICK_REFERENCE.md
-- CHANGELOG.md
-- etc.
+- README.md, INSTALLATION_GUIDE.md, QUICK_REFERENCE.md, CHANGELOG.md, etc.
 
-The skill should only contain the information needed for an AI agent to do the job at hand. It should not contain auxilary context about the process that went into creating it, setup and testing procedures, user-facing documentation, etc. Creating additional documentation files just adds clutter and confusion.
+The skill should only contain information needed for an AI agent to do the job. No auxiliary context about skill creation process, setup procedures, or user-facing documentation.
 
-### Progressive Disclosure Design Principle
+## Progressive Disclosure Patterns
 
-Skills use a three-level loading system to manage context efficiently:
+Keep references one level deep from SKILL.md. For files longer than 100 lines, include a table of contents at the top. See [references/output-patterns.md](references/output-patterns.md) for detailed examples of the following patterns:
 
-1. **Metadata (name + description)** - Always in context (~100 words)
-2. **SKILL.md body** - When skill triggers (<5k words)
-3. **Bundled resources** - As needed by Claude (Unlimited because scripts can be executed without reading into context window)
-
-#### Progressive Disclosure Patterns
-
-Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. Split content into separate files when approaching this limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
-
-**Key principle:** When a skill supports multiple variations, frameworks, or options, keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details (patterns, examples, configuration) into separate reference files.
-
-**Pattern 1: High-level guide with references**
-
-```markdown
-# PDF Processing
-
-## Quick start
-
-Extract text with pdfplumber:
-[code example]
-
-## Advanced features
-
-- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
-- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
-- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
-```
-
-Claude loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
-
-**Pattern 2: Domain-specific organization**
-
-For Skills with multiple domains, organize content by domain to avoid loading irrelevant context:
-
-```
-bigquery-skill/
-├── SKILL.md (overview and navigation)
-└── reference/
-    ├── finance.md (revenue, billing metrics)
-    ├── sales.md (opportunities, pipeline)
-    ├── product.md (API usage, features)
-    └── marketing.md (campaigns, attribution)
-```
-
-When a user asks about sales metrics, Claude only reads sales.md.
-
-Similarly, for skills supporting multiple frameworks or variants, organize by variant:
-
-```
-cloud-deploy/
-├── SKILL.md (workflow + provider selection)
-└── references/
-    ├── aws.md (AWS deployment patterns)
-    ├── gcp.md (GCP deployment patterns)
-    └── azure.md (Azure deployment patterns)
-```
-
-When the user chooses AWS, Claude only reads aws.md.
-
-**Pattern 3: Conditional details**
-
-Show basic content, link to advanced content:
-
-```markdown
-# DOCX Processing
-
-## Creating documents
-
-Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
-
-## Editing documents
-
-For simple edits, modify the XML directly.
-
-**For tracked changes**: See [REDLINING.md](REDLINING.md)
-**For OOXML details**: See [OOXML.md](OOXML.md)
-```
-
-Claude reads REDLINING.md or OOXML.md only when the user needs those features.
-
-**Important guidelines:**
-
-- **Avoid deeply nested references** - Keep references one level deep from SKILL.md. All reference files should link directly from SKILL.md.
-- **Structure longer reference files** - For files longer than 100 lines, include a table of contents at the top so Claude can see the full scope when previewing.
+- **Pattern 1: High-level guide with references** — SKILL.md contains a quick start; Claude loads detailed reference files (e.g., FORMS.md, REFERENCE.md) only when needed.
+- **Pattern 2: Domain-specific organization** — SKILL.md provides overview and navigation; domain files (e.g., `reference/finance.md`, `reference/sales.md`) are loaded per-query.
+- **Pattern 3: Conditional details** — SKILL.md covers the common path; edge-case details live in dedicated files (e.g., REDLINING.md for tracked changes).
 
 ## Skill Creation Process
-
-Skill creation involves these steps:
 
 1. Understand the skill with concrete examples
 2. Plan reusable skill contents (scripts, references, assets)
@@ -216,52 +95,40 @@ Follow these steps in order, skipping only if there is a clear reason why they a
 
 Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
 
-To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
-
-For example, when building an image-editor skill, relevant questions include:
+Clearly understand concrete examples of how the skill will be used. For example, when building an image-editor skill, relevant questions include:
 
 - "What functionality should the image-editor skill support? Editing, rotating, anything else?"
 - "Can you give some examples of how this skill would be used?"
-- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
 - "What would a user say that should trigger this skill?"
 
-To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+Avoid asking too many questions in a single message. Start with the most important and follow up as needed.
 
 Conclude this step when there is a clear sense of the functionality the skill should support.
 
 ### Step 2: Planning the Reusable Skill Contents
 
-To turn concrete examples into an effective skill, analyze each example by:
+Analyze each concrete example by:
 
 1. Considering how to execute on the example from scratch
-2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+2. Identifying what scripts, references, and assets would help when executing these workflows repeatedly
 
-Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
-
+Example: When building a `pdf-editor` skill for "Help me rotate this PDF":
 1. Rotating a PDF requires re-writing the same code each time
-2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+2. A `scripts/rotate_pdf.py` script would be helpful
 
-Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
-
+Example: When building a `frontend-webapp-builder` skill for "Build me a todo app":
 1. Writing a frontend webapp requires the same boilerplate HTML/React each time
-2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+2. An `assets/hello-world/` template would be helpful
 
-Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
-
-1. Querying BigQuery requires re-discovering the table schemas and relationships each time
-2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
-
-To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+Example: When building a `big-query` skill for "How many users logged in today?":
+1. Querying BigQuery requires re-discovering table schemas each time
+2. A `references/schema.md` file documenting schemas would be helpful
 
 ### Step 3: Initializing the Skill
 
-At this point, it is time to actually create the skill.
+Skip this step only if the skill already exists and iteration or packaging is needed.
 
-Skip this step only if the skill being developed already exists, and iteration or packaging is needed. In this case, continue to the next step.
-
-When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
-
-Usage:
+When creating a new skill from scratch, always run the `init_skill.py` script:
 
 ```bash
 scripts/init_skill.py <skill-name> --path <output-directory>
@@ -274,28 +141,22 @@ The script:
 - Creates example resource directories: `scripts/`, `references/`, and `assets/`
 - Adds example files in each directory that can be customized or deleted
 
-After initialization, customize or remove the generated SKILL.md and example files as needed.
-
 ### Step 4: Edit the Skill
 
-When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of Claude to use. Include information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+The skill is being created for another instance of Claude to use. Include information that would be beneficial and non-obvious to Claude.
 
 #### Learn Proven Design Patterns
-
-Consult these helpful guides based on your skill's needs:
 
 - **Multi-step processes**: See references/workflows.md for sequential workflows and conditional logic
 - **Specific output formats or quality standards**: See references/output-patterns.md for template and example patterns
 
-These files contain established best practices for effective skill design.
-
 #### Start with Reusable Skill Contents
 
-To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+Implement the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input (e.g., brand assets or documentation to include).
 
-Added scripts must be tested by actually running them to ensure there are no bugs and that the output matches what is expected. If there are many similar scripts, only a representative sample needs to be tested to ensure confidence that they all work while balancing time to completion.
+Added scripts must be tested by actually running them to ensure there are no bugs and that output matches expectations. If there are many similar scripts, only a representative sample needs to be tested.
 
-Any example files and directories not needed for the skill should be deleted. The initialization script creates example files in `scripts/`, `references/`, and `assets/` to demonstrate structure, but most skills won't need all of them.
+Delete any example files and directories not needed for the skill.
 
 #### Update SKILL.md
 
@@ -306,10 +167,10 @@ Any example files and directories not needed for the skill should be deleted. Th
 Write the YAML frontmatter with `name` and `description`:
 
 - `name`: The skill name
-- `description`: This is the primary triggering mechanism for your skill, and helps Claude understand when to use the skill.
-  - Include both what the Skill does and specific triggers/contexts for when to use it.
-  - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
-  - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+- `description`: The primary triggering mechanism for the skill.
+  - Include both what the skill does and specific triggers/contexts for when to use it.
+  - Include all "when to use" information here—not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
+  - Example for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
 
 Do not include any other fields in YAML frontmatter.
 
@@ -319,7 +180,7 @@ Write instructions for using the skill and its bundled resources.
 
 ### Step 5: Packaging a Skill
 
-Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
+Once development is complete, package the skill into a distributable .skill file:
 
 ```bash
 scripts/package_skill.py <path/to/skill-folder>
@@ -334,19 +195,18 @@ scripts/package_skill.py <path/to/skill-folder> ./dist
 The packaging script will:
 
 1. **Validate** the skill automatically, checking:
-
    - YAML frontmatter format and required fields
    - Skill naming conventions and directory structure
    - Description completeness and quality
    - File organization and resource references
 
-2. **Package** the skill if validation passes, creating a .skill file named after the skill (e.g., `my-skill.skill`) that includes all files and maintains the proper directory structure for distribution. The .skill file is a zip file with a .skill extension.
+2. **Package** the skill if validation passes, creating a .skill file (e.g., `my-skill.skill`) that includes all files and maintains proper directory structure. The .skill file is a zip file with a .skill extension.
 
-If validation fails, the script will report the errors and exit without creating a package. Fix any validation errors and run the packaging command again.
+If validation fails, the script reports errors and exits without creating a package. Fix any validation errors and run the packaging command again.
 
 ### Step 6: Iterate
 
-After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+After testing the skill, users may request improvements.
 
 **Iteration workflow:**
 

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
+description: "Test-driven development with red-green-refactor loop: write failing tests first, implement minimal passing code, then refactor for quality. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development."
 ---
 
 # Test-Driven Development
@@ -9,24 +9,38 @@ description: Test-driven development with red-green-refactor loop. Use when user
 
 **Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
 
-**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+**Good tests** are integration-style: they exercise real code paths through public APIs and describe _what_ the system does, not _how_. A good test reads like a specification — "user can checkout with valid cart."
 
-**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+**Rules**:
+- Use public interfaces only — never test private methods or internal collaborators
+- If a test breaks during a refactor where behavior hasn't changed, the test is testing implementation, not behavior
 
 See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
 
+## Behavior-Focused vs. Implementation-Focused Tests
+
+A quick illustration of the distinction (Python, but the principle is language-agnostic):
+
+```python
+# BAD — tests implementation detail (internal method name, internal state)
+def test_cart_internal():
+    cart = Cart()
+    cart._item_list.append(Item("book", 10))   # reaches into internals
+    assert cart._calculate_subtotal() == 10    # calls private method
+
+# GOOD — tests observable behavior through public interface
+def test_cart_total_reflects_added_items():
+    cart = Cart()
+    cart.add_item("book", price=10)
+    cart.add_item("pen",  price=2)
+    assert cart.total() == 12
+```
+
+The good test survives any internal refactor as long as `add_item` and `total` keep their contract.
+
 ## Anti-Pattern: Horizontal Slices
 
-**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
-
-This produces **crap tests**:
-
-- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
-- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behavior
-- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
-- You outrun your headlights, committing to test structure before understanding the implementation
-
-**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+**DO NOT write all tests first, then all implementation.** Tests written in bulk test _imagined_ behavior and become insensitive to real changes.
 
 ```
 WRONG (horizontal):
@@ -39,6 +53,8 @@ RIGHT (vertical):
   RED→GREEN: test3→impl3
   ...
 ```
+
+**Correct approach**: Vertical slices via tracer bullets — one test → one implementation → repeat.
 
 ## Workflow
 
@@ -67,6 +83,34 @@ GREEN: Write minimal code to pass → test passes
 ```
 
 This is your tracer bullet - proves the path works end-to-end.
+
+**Example RED→GREEN cycle** (pytest):
+
+```python
+# --- RED: write the test first, run it, watch it fail ---
+def test_user_can_register_with_valid_email():
+    service = UserService()
+    user = service.register(email="alice@example.com", password="s3cret")
+    assert user.id is not None
+    assert user.email == "alice@example.com"
+
+# Running now → NameError / AttributeError: UserService does not exist  ✗
+
+# --- GREEN: write the minimal implementation to make it pass ---
+import uuid
+
+class UserService:
+    def register(self, email: str, password: str):
+        return User(id=uuid.uuid4(), email=email)
+
+class User:
+    def __init__(self, id, email):
+        self.id = id
+        self.email = email
+
+# Running now → passes  ✓
+# (password hashing, persistence, validation come in later cycles)
+```
 
 ### 3. Incremental Loop
 

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow
-description: "Workflow orchestration for complex coding tasks. Use for ANY non-trivial task (3+ steps or architectural decisions) to enforce planning, subagent strategy, self-improvement, verification, elegance, and autonomous bug fixing. Triggers: multi-step implementation, bug fixes, refactoring, architectural changes, or any task requiring structured execution."
+description: "Workflow orchestration for complex coding tasks. Use when a task involves 3+ steps, spans multiple files, or requires architectural decisions — enforcing upfront planning, subtask breakdown, subagent delegation, cross-file verification, and structured bug investigation. Use when: multi-step feature implementation, complex bug fixes requiring investigation across multiple files, large-scale refactoring, architectural changes, or any task needing a validated execution plan before coding begins."
 ---
 
 ## Workflow Orchestration
@@ -11,6 +11,18 @@ description: "Workflow orchestration for complex coding tasks. Use for ANY non-t
 - If something goes sideways, STOP and re-plan immediately — don't keep pushing
 - Use plan mode for verification steps, not just building
 - Write detailed specs upfront to reduce ambiguity
+
+**Example plan mode output** (written to `tasks/todo.md` before coding begins):
+```
+## Task: Add OAuth2 login support
+
+- [ ] Audit existing auth middleware in `src/auth/`
+- [ ] Design token storage schema (DB migration required)
+- [ ] Implement OAuth2 callback handler in `src/routes/auth.ts`
+- [ ] Wire up session persistence and expiry
+- [ ] Write integration tests covering happy path + token refresh
+- [ ] Verify no regressions in existing session-based login
+```
 
 ### 2. Subagent Strategy
 
@@ -25,6 +37,15 @@ description: "Workflow orchestration for complex coding tasks. Use for ANY non-t
 - Write rules for yourself that prevent the same mistake
 - Ruthlessly iterate on these lessons until mistake rate drops
 - Review lessons at session start for relevant project
+
+**Example `tasks/lessons.md` entry:**
+```
+## Lesson: 2024-06-10 — Don't mutate shared config objects
+
+**What happened:** Modified a shared config object in place; broke unrelated tests.
+**Root cause:** Assumed config was local scope; it was imported by reference.
+**Rule:** Always deep-clone config objects before modification. Use `structuredClone()` or spread at the call site.
+```
 
 ### 4. Verification Before Done
 
@@ -55,6 +76,16 @@ description: "Workflow orchestration for complex coding tasks. Use for ANY non-t
 4. **Explain Changes**: High-level summary at each step
 5. **Document Results**: Add review section to `tasks/todo.md`
 6. **Capture Lessons**: Update `tasks/lessons.md` after corrections
+
+**Example completed `tasks/todo.md` review section:**
+```
+## Review
+
+- [x] OAuth2 callback handler implemented and tested
+- [x] Session expiry confirmed via manual smoke test + unit tests
+- [x] No regressions: existing session login tests all green
+- Lesson captured: always validate redirect_uri against allowlist before exchange
+```
 
 ## Core Principles
 


### PR DESCRIPTION
Hullo @brianlovin 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="1670" alt="score_card" src="https://github.com/user-attachments/assets/8fc59ea2-d82e-4be3-8f13-1892cd08389a" />

Here's the before/after in text form:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| sentry | 60% | 100% | +40% |
| simplify | 59% | 89% | +30% |
| deslop | 74% | 100% | +26% |
| rams | 81% | 100% | +19% |
| skill-creator | 76% | 93% | +17% |
| workflow | 80% | 96% | +16% |
| bun | 86% | 100% | +14% |
| playwriter | 83% | 96% | +13% |
| favicon | 76% | 89% | +13% |
| find-skills | 84% | 93% | +9% |
| react-doctor | 91% | 100% | +9% |
| knip | 81% | 89% | +8% |
| agent-browser | 90% | 96% | +6% |
| tdd | 88% | 93% | +5% |
| chrome-webstore-release-blueprint | 89% | 89% | 0% |

Average score improved from 80% to 95% (+15% overall).

Skills not modified: electron-wrapper (already 100%), fix-sentry-issues (already 96%, no improvements found), reclaude (blocked by reserved word in name field).

Changes include: expanded frontmatter descriptions with trigger terms and "Use when" clauses, added concrete before/after code examples, structured workflows with validation steps, removed redundant explanatory text, extracted verbose sections to reference files, and added error handling guidance.

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

If you want to run reviews, evals and optimizations yourself, just `npm install @tessl/cli` then run `tessl skill review path/to/your/SKILL.md`, and click here to find out more: https://tessl.io/registry/skills/submit